### PR TITLE
Fix: remove unnecessary docker builds

### DIFF
--- a/linux_malware_analysis_container.sh
+++ b/linux_malware_analysis_container.sh
@@ -10,7 +10,7 @@ fi
 image_name="linux-malware-analysis"
 container_name="${image_name}_$(date +%s)"
 
-# Build container if it doesn't exist
+# Build docker image if it doesn't exist
 if [[ "$(docker images -q $image_name 2> /dev/null)" == "" ]]; then
   docker build -t $image_name .
 fi
@@ -19,8 +19,7 @@ fi
 tar_file="$(mktemp)"
 tar -cf "$tar_file" "$@"
 
-# Build and run container
-docker build -t $image_name .
+# Run container
 docker run -d --network none --name $container_name $image_name sleep infinity
 
 # Copy the tar file to the Docker container


### PR DESCRIPTION
I was using the script and noticed that docker build command being run every time. It doesn't harm because of docker cache but anyways here's a patch.